### PR TITLE
docs(posts): Build //localhost:Daegu 연사자 직함 정정

### DIFF
--- a/src/MatdaAIga.Generator/input/posts/2026/06/microsoft-build-localhost-daegu.md
+++ b/src/MatdaAIga.Generator/input/posts/2026/06/microsoft-build-localhost-daegu.md
@@ -50,7 +50,7 @@ HeroImage: /images/posts/2026/06/microsoft-build-localhost-daegu.png
 
 ## 🎤 연사자 정보
 
-- **김근희** · Microsoft Student Ambassadors Senior
+- **김근희** · Microsoft Education Success Manager
 - **유저스틴** · Microsoft Principal Developer Advocate
 - **이보라** · Microsoft MVP, 모던웹연구소
 - **황지현** · Microsoft Student Ambassadors Senior


### PR DESCRIPTION
## 요약
- Microsoft Build //localhost:Daegu 게시글의 연사자 정보를 정정했습니다.
- 김근희 연사자의 직함을 `Microsoft Education Success Manager`로 수정했습니다.

## 변경 사항
- `src/MatdaAIga.Generator/input/posts/2026/06/microsoft-build-localhost-daegu.md`

## 변경 이유
- 행사 정보 정확도를 높이기 위해 최신 직함으로 반영했습니다.
