### PR TITLE
fix(posts): 7월 밋업 포스트 게시일 수정

### DIFF
--- a/src/MatdaAIga.Generator/input/posts/2026/07/matdaaiga-2026-07-meetup.md
+++ b/src/MatdaAIga.Generator/input/posts/2026/07/matdaaiga-2026-07-meetup.md
@@ -1,6 +1,6 @@
 Title: 2026년 7월 MeetUp - 하네스 엔지니어링
 Lead: 에이전트 개발의 모든 것을 알아갈까요?
-Published: 2026-06-24
+Published: 2026-06-27
 Tags:
   - AI
   - Agent


### PR DESCRIPTION
## 변경 사항

2026년 7월 MeetUp - 하네스 엔지니어링 포스트의 게시일을 `2026-06-24` → `2026-06-27`로 수정했습니다.

## 배경

Microsoft Build //localhost:Daegu 후기 포스트의 게시일이 `2026-06-25`로 설정되어 있어, 더 최신 콘텐츠인 하네스 엔지니어링 포스트(`2026-06-24`)가 목록에서 아래로 밀리는 정렬 문제가 있었습니다. 게시일을 `2026-06-27`로 조정하여 하네스 엔지니어링 포스트가 목록 최상단에 노출되도록 했습니다.