### PR TITLE
Add Matdathon redirect pages

### DIFF
--- a/src/MatdaAIga.Generator/input/matdathon.html
+++ b/src/MatdaAIga.Generator/input/matdathon.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="robots" content="noindex">
+  <meta http-equiv="refresh" content="0;url=https://bit.ly/matdathon-2026">
+  <link rel="canonical" href="https://bit.ly/matdathon-2026">
+  <title>Redirecting to Matdathon 2026</title>
+</head>
+<body>
+  <p>Continue to <a href="https://bit.ly/matdathon-2026">Matdathon 2026</a>.</p>
+</body>
+</html>

--- a/src/MatdaAIga.Generator/input/matdathon/community.html
+++ b/src/MatdaAIga.Generator/input/matdathon/community.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="robots" content="noindex">
+  <meta http-equiv="refresh" content="0;url=https://github.com/matdaaiga-kr/matdathon-2026/discussions">
+  <link rel="canonical" href="https://github.com/matdaaiga-kr/matdathon-2026/discussions">
+  <title>Redirecting to the Matdathon 2026 community</title>
+</head>
+<body>
+  <p>Continue to the <a href="https://github.com/matdaaiga-kr/matdathon-2026/discussions">Matdathon 2026 community</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- add `/matdathon` redirecting to the Matdathon 2026 short URL
- add `/matdathon/community` redirecting to the GitHub Discussions community
- include canonical metadata, `noindex`, and fallback links on both pages

## Validation

- `dotnet run --project .\src\MatdaAIga.Generator\MatdaAIga.Generator.csproj -- --nocache`
- confirmed both generated HTML files contain the expected redirect targets