### PR TITLE
chore: redirect matdathon short page to GitHub README

### DIFF
--- a/src/MatdaAIga.Generator/input/matdathon.html
+++ b/src/MatdaAIga.Generator/input/matdathon.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="robots" content="noindex">
-  <meta http-equiv="refresh" content="0;url=https://github.com/matdaaiga-kr/matdathon-2026#readme">
-  <link rel="canonical" href="https://github.com/matdaaiga-kr/matdathon-2026#readme">
+  <meta http-equiv="refresh" content="0;url=https://github.com/matdaaiga-kr/matdathon-2026">
+  <link rel="canonical" href="https://github.com/matdaaiga-kr/matdathon-2026">
   <title>Redirecting to Matdathon 2026</title>
 </head>
 <body>

--- a/src/MatdaAIga.Generator/input/matdathon.html
+++ b/src/MatdaAIga.Generator/input/matdathon.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="robots" content="noindex">
-  <meta http-equiv="refresh" content="0;url=https://bit.ly/matdathon-2026">
-  <link rel="canonical" href="https://bit.ly/matdathon-2026">
+  <meta http-equiv="refresh" content="0;url=https://github.com/matdaaiga-kr/matdathon-2026#readme">
+  <link rel="canonical" href="https://github.com/matdaaiga-kr/matdathon-2026#readme">
   <title>Redirecting to Matdathon 2026</title>
 </head>
 <body>
-  <p>Continue to <a href="https://bit.ly/matdathon-2026">Matdathon 2026</a>.</p>
+  <p>Continue to the <a href="https://github.com/matdaaiga-kr/matdathon-2026#readme">Matdathon 2026 README</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
### 변경사항

- 기존 : matdaaiga.kr/matdathon 페이지가 bit.ly/matdathon-2026 으로 연결

- 변경: 해커톤 참가자 대상 사전안내를 위해 matdaaiga.kr/matdathon 페이지를 [깃헙 맞다톤 README URL](https://github.com/matdaaiga-kr/matdathon-2026#readme)로 변경한다.

- 추후 사용 방식: 참가자 대상으로 이메일 사전 안내 시 matdaaiga.kr/matdathon 페이지로 안내.